### PR TITLE
Support of collecting also values defined in dependency management.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 bom-builder-maven-plugin
 ========================
 
-A Maven plugin to generate a dependency management POM, sometimes called a 
-BOM or bill of materials POM.  The plugin reads the set of dependencies in 
-the current project, and writes a new POM to "target/bom-pom.xml" which
-contains a dependency management section listing the dependencies of
-the current project.
+A Maven plugin to generate a dependency management POM, sometimes called
+a BOM or bill of materials POM. The plugin reads the set of dependencies
+in the current project, and writes a new POM to "target/bom-pom.xml"
+which contains a dependency management section listing the dependencies
+of the current project.
 
 
 Usage
 -----
+
 The plugin is configured in the "plugins" section of the pom.
 
     <plugins>
@@ -35,29 +36,36 @@ The plugin is configured in the "plugins" section of the pom.
       </plugin>
     </plugins>
 
-
 Config Parameters
 -----------------
-bomGroupId - The groupId to set in the generated BOM
-bomArtifactId - The artifactId to set in the generated BOM
-bomVersion - The version to set in the generated BOM
-bomName - The name to set in the generated BOM
-bomDescription - The description to set in the generated BOM
-exclusions - A list of exclusions to set in the genertated BOM
-dependencyExclusions - A list of dependencies which should not be included in the genertated BOM
+
+|               Config                |                                Description                                |
+|:------------------------------------|:--------------------------------------------------------------------------|
+| bomGroupId                          | The groupId to set in the generated BOM                                   |
+| bomArtifactId                       | The artifactId to set in the generated BOM                                |
+| bomVersion                          | The version to set in the generated BOM                                   |
+| bomName                             | The name to set in the generated BOM                                      |
+| bomDescription                      | The description to set in the generated BOM                               |
+| exclusions                          | A list of exclusions to set in the genertated BOM                         |
+| dependencyExclusions                | A list of dependencies which should not be included in the genertated BOM |
+| useArtifacts                        | Use all dependencies and transitive dependencies (default: true)          |
+| useDependencies                     | Use only defined dependencies (default: false)                            |
+| useDependencyManagementDependencies | Use dependency management dependencies (default: false)                   |
 
 Each exclusion should contain four parameters:
-  - dependencyGroupId
-  - dependencyArtifactId
-  - exclusionGroupId
-  - exclusionArtifactId
+
+- dependencyGroupId
+- dependencyArtifactId
+- exclusionGroupId
+- exclusionArtifactId
 
 Each dependency exclusion should contain two parameters:
-  - groupId
-  - artifactId
+
+- groupId
+- artifactId
 
 Exclusion Config Example
--------------------
+------------------------
 
     <configuration>
       <bomGroupId>org.test</bomGroupId>
@@ -73,7 +81,8 @@ Exclusion Config Example
       </exclusions>
     </configuration>
 
-The above config will result in POM output that looks similar to the following:
+The above config will result in POM output that looks similar to the
+following:
 
     <dependency>
       <groupId>junit</groupId>
@@ -88,7 +97,7 @@ The above config will result in POM output that looks similar to the following:
     </dependency>
 
 Dependency Exclusion Config Example
--------------------
+-----------------------------------
 
     <configuration>
       <bomGroupId>org.test</bomGroupId>
@@ -102,10 +111,12 @@ Dependency Exclusion Config Example
       </dependencyExclusions>
     </configuration>
 
-The above config will result in POM which will not contain junit dependency
+The above config will result in POM which will not contain junit
+dependency
 
-You can use * for value of artifactId (or groupId) to exclude all dependencies with given groupId and any artifactId
-(or with given artifactId and any groupId)
+You can use * for value of artifactId (or groupId) to exclude all
+dependencies with given groupId and any artifactId (or with given
+artifactId and any groupId)
 
 Using properties for version
 ----------------------------
@@ -117,4 +128,5 @@ Using properties for version
       <usePropertiesForVersion>true</usePropertiesForVersion>
     </configuration>
 
-The above config will result in POM where version of dependencies is specified via properties.
+The above config will result in POM where version of dependencies is
+specified via properties.

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,9 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <mavenVersion>3.0.4</mavenVersion>
-    <mavenPluginPluginVersion>3.2</mavenPluginPluginVersion>
+    <mavenPluginAnnotationVersion>3.3</mavenPluginAnnotationVersion>
+    <mavenPluginPluginVersion>3.3</mavenPluginPluginVersion>
+    <version.surefire.plugin>2.22.0</version.surefire.plugin>
 
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -68,7 +70,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>${mavenPluginPluginVersion}</version>
+      <version>${mavenPluginAnnotationVersion}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -89,6 +91,19 @@
   </dependencies>
 
   <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${version.surefire.plugin}</version>
+        <configuration>
+          <forkCount>3</forkCount>
+          <reuseForks>true</reuseForks>
+          <argLine>-Xmx1024m -Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+
     <pluginManagement>
       <plugins>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <mavenVersion>3.0.4</mavenVersion>
     <mavenPluginPluginVersion>3.2</mavenPluginPluginVersion>
+
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
 
   <dependencies>

--- a/src/main/java/org/jboss/maven/plugins/bombuilder/BuildBomMojo.java
+++ b/src/main/java/org/jboss/maven/plugins/bombuilder/BuildBomMojo.java
@@ -5,9 +5,13 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
@@ -38,6 +42,7 @@ public class BuildBomMojo
 {
 
     private static final String VERSION_PROPERTY_PREFIX = "version.";
+
     /**
      * BOM groupId
      */
@@ -102,6 +107,24 @@ public class BuildBomMojo
     boolean usePropertiesForVersion;
 
     /**
+     * Whether to use dependency management dependencies.
+     */
+    @Parameter(defaultValue = "false")
+    private boolean useDependencyManagementDependencies;
+
+    /**
+     * Wheter to use dependencies.
+     */
+    @Parameter(defaultValue = "false")
+    private boolean useDependencies;
+
+    /**
+     * Wheter to use all resolved dependencies (defaults to true).
+     */
+    @Parameter(defaultValue = "true")
+    private boolean useArtifacts;
+
+    /**
      * The current project
      */
     @Component
@@ -163,67 +186,93 @@ public class BuildBomMojo
         return pomModel;
     }
 
-    private void addDependencyManagement( Model pomModel )
-    {
-        // Sort the artifacts for readability
-        List<Artifact> projectArtifacts = new ArrayList<Artifact>( mavenProject.getArtifacts() );
-        Collections.sort( projectArtifacts );
+    private void addDependencyManagement( Model pomModel ) {
+        List<Dependency> dependencies = new LinkedList<>();
 
-        Properties versionProperties = new Properties();
-        DependencyManagement depMgmt = new DependencyManagement();
-        for ( Artifact artifact : projectArtifacts )
-        {
-            if (isExcludedDependency(artifact)) {
-                continue;
-            }
-
-            String versionPropertyName = VERSION_PROPERTY_PREFIX + artifact.getGroupId();
-            if (versionProperties.getProperty(versionPropertyName) != null
-                && !versionProperties.getProperty(versionPropertyName).equals(artifact.getVersion())) {
-                versionPropertyName = VERSION_PROPERTY_PREFIX + artifact.getGroupId() + "." + artifact.getArtifactId();
-            }
-            versionProperties.setProperty(versionPropertyName, artifact.getVersion());
-
-            Dependency dep = new Dependency();
-            dep.setGroupId( artifact.getGroupId() );
-            dep.setArtifactId( artifact.getArtifactId() );
-            dep.setVersion( artifact.getVersion() );
-            if ( !StringUtils.isEmpty( artifact.getClassifier() ))
-            {
-                dep.setClassifier( artifact.getClassifier() );
-            }
-            if ( !StringUtils.isEmpty( artifact.getType() ))
-            {
-                dep.setType( artifact.getType() );
-            }
-            if (exclusions != null) {
-                applyExclusions(artifact, dep);
-            }
-            depMgmt.addDependency( dep );
+        if (useArtifacts) {
+            dependencies.addAll(getArtifactsAsDependencies());
         }
-        pomModel.setDependencyManagement( depMgmt );
+        if (useDependencies) {
+            dependencies.addAll(getDependencies());
+        }
+        if (useDependencyManagementDependencies) {
+            dependencies.addAll(getDependencyManagementDependencies());
+        }
+
+        final DependencyManagement depMgmt = new DependencyManagement();
+        dependencies.stream()
+                .sorted(Comparator.comparing(Dependency::getGroupId).thenComparing(Dependency::getArtifactId))
+                .forEach(depMgmt::addDependency);
+
         if (addVersionProperties) {
+            Properties versionProperties = generateVersionProperties(dependencies);
             pomModel.getProperties().putAll(versionProperties);
         }
-        getLog().debug( "Added " + projectArtifacts.size() + " dependencies." );
+
+        pomModel.setDependencyManagement(depMgmt);
+        getLog().debug( "Added " + dependencies.size() + " dependencies." );
     }
 
-    boolean isExcludedDependency(Artifact artifact) {
+    private List<Dependency> getArtifactsAsDependencies() {
+        return mavenProject.getArtifacts().stream()
+                .map(this::map)
+                .filter(this::isDependencyNotExcluded)
+                .collect(Collectors.toList());
+    }
+
+    private List<Dependency> getDependencies() {
+        return mavenProject.getDependencies().stream()
+                .map(Dependency::clone)
+                .filter(this::isDependencyNotExcluded)
+                .collect(Collectors.toList());
+    }
+
+    private List<Dependency> getDependencyManagementDependencies() {
+        final DependencyManagement dependencyManagement = mavenProject.getDependencyManagement();
+        if (dependencyManagement == null) {
+            return Collections.emptyList();
+        }
+        return dependencyManagement.getDependencies().stream()
+                .map(Dependency::clone)
+                .filter(this::isDependencyNotExcluded)
+                .collect(Collectors.toList());
+    }
+
+    private Dependency map(Artifact artifact) {
+        Dependency dep = new Dependency();
+        dep.setGroupId( artifact.getGroupId() );
+        dep.setArtifactId( artifact.getArtifactId() );
+        dep.setVersion( artifact.getVersion() );
+        if ( !StringUtils.isEmpty( artifact.getClassifier() ))
+        {
+            dep.setClassifier( artifact.getClassifier() );
+        }
+        if ( !StringUtils.isEmpty( artifact.getType() ))
+        {
+            dep.setType( artifact.getType() );
+        }
+        if (exclusions != null) {
+            applyExclusions(artifact, dep);
+        }
+        return dep;
+    }
+
+    boolean isDependencyNotExcluded(Dependency dependency) {
         if (dependencyExclusions == null || dependencyExclusions.size() == 0) {
-            return false;
+            return true;
         }
         for (DependencyExclusion exclusion : dependencyExclusions) {
-            if (matchesExcludedDependency(artifact, exclusion)) {
-                getLog().debug( "Artifact " + artifact.getGroupId() + ":" + artifact.getArtifactId() + " matches excluded dependency " + exclusion.getGroupId() + ":" + exclusion.getArtifactId() );
-                return  true;
+            if (matchesExcludedDependency(dependency, exclusion)) {
+                getLog().debug( "Dependency " + dependency.getGroupId() + ":" + dependency.getArtifactId() + " matches excluded dependency " + exclusion.getGroupId() + ":" + exclusion.getArtifactId() );
+                return false;
             }
         }
-        return false;
+        return true;
     }
 
-    boolean matchesExcludedDependency(Artifact artifact, DependencyExclusion exclusion) {
-        String groupId = defaultAndTrim(artifact.getGroupId());
-        String artifactId = defaultAndTrim(artifact.getArtifactId());
+    boolean matchesExcludedDependency(Dependency dependency, DependencyExclusion exclusion) {
+        String groupId = defaultAndTrim(dependency.getGroupId());
+        String artifactId = defaultAndTrim(dependency.getArtifactId());
         String exclusionGroupId = defaultAndTrim(exclusion.getGroupId());
         String exclusionArtifactId = defaultAndTrim(exclusion.getArtifactId());
         boolean groupIdMatched = ("*".equals (exclusionGroupId) || groupId.equals(exclusionGroupId));
@@ -247,6 +296,18 @@ public class BuildBomMojo
         }
     }
 
+    private Properties generateVersionProperties(List<Dependency> dependencies) {
+        Properties versionProperties = new Properties();
+        dependencies.forEach(dependency -> {
+            String versionPropertyName = VERSION_PROPERTY_PREFIX + dependency.getGroupId();
+            if (versionProperties.getProperty(versionPropertyName) != null
+                    && !versionProperties.getProperty(versionPropertyName).equals(dependency.getVersion())) {
+                versionPropertyName = VERSION_PROPERTY_PREFIX + dependency.getGroupId() + "." + dependency.getArtifactId();
+            }
+            versionProperties.setProperty(versionPropertyName, dependency.getVersion());
+        });
+        return versionProperties;
+    }
 
     static class ModelWriter {
 

--- a/src/main/java/org/jboss/maven/plugins/bombuilder/BuildBomMojo.java
+++ b/src/main/java/org/jboss/maven/plugins/bombuilder/BuildBomMojo.java
@@ -160,7 +160,7 @@ public class BuildBomMojo
         getLog().debug( "Generating BOM" );
         Model model = initializeModel();
         addDependencyManagement( model );
-        if (addVersionProperties) {
+        if (usePropertiesForVersion) {
             model = versionsTransformer.transformPomModel(model);
             getLog().debug( "Dependencies versions converted to properties" );
         }
@@ -204,7 +204,7 @@ public class BuildBomMojo
                 .sorted(Comparator.comparing(Dependency::getGroupId).thenComparing(Dependency::getArtifactId))
                 .forEach(depMgmt::addDependency);
 
-        if (usePropertiesForVersion) {
+        if (addVersionProperties) {
             Properties versionProperties = generateVersionProperties(dependencies);
             pomModel.getProperties().putAll(versionProperties);
         }

--- a/src/main/java/org/jboss/maven/plugins/bombuilder/BuildBomMojo.java
+++ b/src/main/java/org/jboss/maven/plugins/bombuilder/BuildBomMojo.java
@@ -71,7 +71,7 @@ public class BuildBomMojo
      * BOM name
      */
     @Parameter
-    private boolean addVersionProperties;
+    boolean addVersionProperties;
 
    /**
      * BOM description
@@ -110,19 +110,19 @@ public class BuildBomMojo
      * Whether to use dependency management dependencies.
      */
     @Parameter(defaultValue = "false")
-    private boolean useDependencyManagementDependencies;
+    boolean useDependencyManagementDependencies;
 
     /**
      * Wheter to use dependencies.
      */
     @Parameter(defaultValue = "false")
-    private boolean useDependencies;
+    boolean useDependencies;
 
     /**
      * Wheter to use all resolved dependencies (defaults to true).
      */
     @Parameter(defaultValue = "true")
-    private boolean useArtifacts;
+    boolean useArtifacts;
 
     /**
      * The current project
@@ -160,7 +160,7 @@ public class BuildBomMojo
         getLog().debug( "Generating BOM" );
         Model model = initializeModel();
         addDependencyManagement( model );
-        if (usePropertiesForVersion) {
+        if (addVersionProperties) {
             model = versionsTransformer.transformPomModel(model);
             getLog().debug( "Dependencies versions converted to properties" );
         }
@@ -204,7 +204,7 @@ public class BuildBomMojo
                 .sorted(Comparator.comparing(Dependency::getGroupId).thenComparing(Dependency::getArtifactId))
                 .forEach(depMgmt::addDependency);
 
-        if (addVersionProperties) {
+        if (usePropertiesForVersion) {
             Properties versionProperties = generateVersionProperties(dependencies);
             pomModel.getProperties().putAll(versionProperties);
         }

--- a/src/test/java/org/jboss/maven/plugins/bombuilder/BuildBomMojoTest.java
+++ b/src/test/java/org/jboss/maven/plugins/bombuilder/BuildBomMojoTest.java
@@ -1,20 +1,18 @@
 package org.jboss.maven.plugins.bombuilder;
 
-import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.DefaultArtifact;
-import org.apache.maven.artifact.handler.ArtifactHandler;
-import org.apache.maven.model.Model;
-import org.apache.maven.project.MavenProject;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
 
 public class BuildBomMojoTest {
 
@@ -57,7 +55,7 @@ public class BuildBomMojoTest {
 
 
     @Test
-    public void testMatchesExcludedDependency() throws Exception {
+    public void testMatchesExcludedDependency() {
         assertArtifactMatchesExcludedDependency(true, "groupId", "artifactId", "groupId", "artifactId");
         assertArtifactMatchesExcludedDependency(true, "groupId", "artifactId", "*", "artifactId");
         assertArtifactMatchesExcludedDependency(true, "groupId", "artifactId", "groupId", "*");
@@ -71,7 +69,7 @@ public class BuildBomMojoTest {
     }
 
     private void assertArtifactMatchesExcludedDependency(boolean expected, String artifactGroupId, String artifactArtifactId, String dependencyGroupId, String dependencyArtifactId) {
-        Artifact artifact = createArtifact(artifactGroupId, artifactArtifactId);
+        Dependency artifact = createDependency(artifactGroupId, artifactArtifactId);
         DependencyExclusion exclusion = createDependencyExclusion(dependencyGroupId, dependencyArtifactId);
         BuildBomMojo mojo = new BuildBomMojo();
         assertEquals(expected, mojo.matchesExcludedDependency(artifact, exclusion));
@@ -81,7 +79,14 @@ public class BuildBomMojoTest {
         return new DependencyExclusion(groupId, artifactId);
     }
 
-    private Artifact createArtifact(String groupId, String artifactId) {
-        return new DefaultArtifact(groupId, artifactId, "version", "scope", "type", "classifier", (ArtifactHandler)null);
+    private Dependency createDependency(String groupId, String artifactId) {
+        final Dependency dependency = new Dependency();
+        dependency.setGroupId(groupId);
+        dependency.setArtifactId(artifactId);
+        dependency.setVersion("version");
+        dependency.setScope("scope");
+        dependency.setType("type");
+        dependency.setClassifier("classifier");
+        return dependency;
     }
 }

--- a/src/test/java/org/jboss/maven/plugins/bombuilder/BuildBomMojoTest.java
+++ b/src/test/java/org/jboss/maven/plugins/bombuilder/BuildBomMojoTest.java
@@ -38,11 +38,14 @@ public class BuildBomMojoTest {
 
     @Test
     public void testDependencyVersionIsStoredInProperties() throws Exception {
+        mojo.addVersionProperties = true;
         mojo.usePropertiesForVersion = true;
-
+        mojo.useArtifacts = true;
+        mojo.useDependencyManagementDependencies = true;
+        mojo.useDependencies = true;
         mojo.execute();
 
-        verify(versionTransformer, times(1)).transformPomModel(any(Model.class));
+        verify(versionTransformer).transformPomModel(any(Model.class));
     }
 
     private BuildBomMojo createBuildBomMojo() {


### PR DESCRIPTION
This new MR brings:
- Update to Java 8
- Allows consumers to define if dependencies should be collected from dependency management, dependencies or (default behavior) all resolved artifacts.