### PR TITLE
Support collecting dependencies from dependency management

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,23 +38,31 @@ The plugin is configured in the "plugins" section of the pom.
 
 Config Parameters
 -----------------
-bomGroupId - The groupId to set in the generated BOM
-bomArtifactId - The artifactId to set in the generated BOM
-bomVersion - The version to set in the generated BOM
-bomName - The name to set in the generated BOM
-bomDescription - The description to set in the generated BOM
-exclusions - A list of exclusions to set in the genertated BOM
-dependencyExclusions - A list of dependencies which should not be included in the genertated BOM
+
+|               Config                |                                Description                                |
+|:------------------------------------|:--------------------------------------------------------------------------|
+| bomGroupId                          | The groupId to set in the generated BOM                                   |
+| bomArtifactId                       | The artifactId to set in the generated BOM                                |
+| bomVersion                          | The version to set in the generated BOM                                   |
+| bomName                             | The name to set in the generated BOM                                      |
+| bomDescription                      | The description to set in the generated BOM                               |
+| exclusions                          | A list of exclusions to set in the genertated BOM                         |
+| dependencyExclusions                | A list of dependencies which should not be included in the genertated BOM |
+| useArtifacts                        | Use all dependencies and transitive dependencies (default: true)          |
+| useDependencies                     | Use only defined dependencies (default: false)                            |
+| useDependencyManagementDependencies | Use dependency management dependencies (default: false)                   |
 
 Each exclusion should contain four parameters:
-  - dependencyGroupId
-  - dependencyArtifactId
-  - exclusionGroupId
-  - exclusionArtifactId
+
+- dependencyGroupId
+- dependencyArtifactId
+- exclusionGroupId
+- exclusionArtifactId
 
 Each dependency exclusion should contain two parameters:
-  - groupId
-  - artifactId
+
+- groupId
+- artifactId
 
 Exclusion Config Example
 -------------------

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <mavenVersion>3.0.4</mavenVersion>
     <mavenPluginPluginVersion>3.2</mavenPluginPluginVersion>
+    <version.surefire.plugin>2.22.0</version.surefire.plugin>
 
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -89,6 +90,20 @@
   </dependencies>
 
   <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${version.surefire.plugin}</version>
+        <configuration>
+          <forkCount>3</forkCount>
+          <reuseForks>true</reuseForks>
+          <!-- Workaround for Java8 Surefire Issue: The forked VM terminated without properly saying goodbye. VM crash -->
+          <argLine>-Xmx1024m -Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+
     <pluginManagement>
       <plugins>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <mavenVersion>3.0.4</mavenVersion>
     <mavenPluginPluginVersion>3.2</mavenPluginPluginVersion>
+
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This MR supports:
- Collecting Dependencies from Dependency Management and from Dependencies

Additionally following changes are applied:
- Update to Java8
- Use MockitoRunner instead of initMocks
- Fix JUnit Execution with Java 8

Detail of the change:
Change implementation to not work with `Artifact` but with `Dependency`, so code can be reused for the new code supporting dependencies and dependencies from dependency management (it looks like white space changes, but methods are extracted and moved)

MR replaces preview MR !4.